### PR TITLE
docs(example app): show design tokens & fonts in action

### DIFF
--- a/examples/simple-app/index.css
+++ b/examples/simple-app/index.css
@@ -1,0 +1,51 @@
+/*  
+ * Example styles using Virtuoso Design System (e.g. `var(--vds-*)`)
+ * https://avkvirtru.github.io/virtuoso-design-system/?path=/docs/basics-design-tokens--page
+ */
+ 
+html {
+  /* why? 62.5% = 10px = 1em / 1rem in most browsers */
+  font-size: 62.5%;
+}
+
+body {
+  font: var(--vds-font-body);
+}
+
+li {
+  margin-bottom: var(--vds-spacer-md);
+}
+
+.ex__spacer--margin {
+  margin-bottom: var(--vds-spacer-md);
+}
+
+.ex__spacer--padding {
+  padding: var(--vds-spacer-sm);
+}
+
+.ex__color--primaryBlue {
+  background-color: var(--vds-color-blue-primary);
+}
+
+.ex__color--primarySlate {
+  background-color: var(--vds-color-slate-primary);
+}
+
+.ex__border--rounded {
+  border-radius: var(--vds-border-radius-md);
+}
+
+.ex__shadow--hover {
+  box-shadow: var(--vds-shadow-hover);
+}
+
+.ex__head--xl { font: var(--vds-font-heading-xl); }
+.ex__head--lg { font: var(--vds-font-heading-lg); }
+.ex__head--md { font: var(--vds-font-heading-md); }
+.ex__head--sm { font: var(--vds-font-heading-sm); }
+.ex__head--xs { font: var(--vds-font-heading-xs); }
+.ex__head--xxs { font: var(--vds-font-heading-xxs); }
+
+.ex__body--md { font: var(--vds-font-md); }
+.ex__body--sm { font: var(--vds-font-sm); }

--- a/examples/simple-app/index.html
+++ b/examples/simple-app/index.html
@@ -1,6 +1,37 @@
-<html>
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8">
+    <title>Simple App Example | Virtuoso Design System </title>
+    
+    <!-- Approach A -->
+    <!-- why? use Design System CSS individually -->
+    <link 
+      rel="stylesheet" 
+      href="https://unpkg.com/virtuoso-design-system@latest/dist/design_tokens.css">
+    <link 
+      rel="stylesheet" 
+      href="https://unpkg.com/browse/virtuoso-design-system@latest/dist/font-style/open-sans.css">
+    <link 
+      rel="stylesheet" 
+      href="https://unpkg.com/browse/virtuoso-design-system@latest/dist/font-style/raleway.css">
+    
+    <!-- Approach B -->
+    <!-- why? if Art could wave a magic wand, all of the above CSS would be available as a single stylesheet -->
+    <!-- 
+    <link 
+      rel="stylesheet" 
+      href="https://unpkg.com/virtuoso-design-system@latest/dist/base.css">
+    -->
+    
+    <!-- why? styles for this example app -->
+    <link rel="stylesheet" href="index.css">
+  </head>
   <body>
+    <!-- why? where React components will render -->
     <div id="mount"></div>
+    
+    <!-- why? include all JavaScript dependencies -->
     <script src="./index.js"></script>
   </body>
 </html>

--- a/examples/simple-app/index.js
+++ b/examples/simple-app/index.js
@@ -7,7 +7,55 @@ function SimpleApp() {
   return (
     <Layout>
       <Layout.Header title="My App"></Layout.Header>
-      Content goes here
+
+
+
+
+
+      <p>Example content showing design tokens in action:</p>
+
+
+
+
+
+      <ul>
+
+        <li className="ex__spacer--margin">
+          Am I at least a medium spacer apart from the next list item?
+        </li>
+        
+        <li className="ex__color--primaryBlue ex__spacer--padding">
+          This background should be primary blue with some ample padding.
+        </li>
+        
+        <li className="ex__spacer--padding ex__color--primarySlate ex__border--rounded">
+          I should be primary slate with a rounded border.
+        </li>
+
+        <li className="ex__shadow--hover">
+          Note my hovering shadow…
+        </li>
+
+      </ul>
+      
+      
+      
+      
+      
+      <section>
+
+        <h1 className="ex__head--xl">Heading XL</h1>
+        <h2 className="ex__head--lg">Heading LG</h2>
+        <h3 className="ex__head--md">Heading MD</h3>
+        <h4 className="ex__head--sm">Heading small</h4>
+        <h5 className="ex__head--xs">Heading xs</h5>
+        <h6 className="ex__head--xxs">Heading xs</h6>
+        
+        <p className="ex__body--md">Body copy</p>
+        <small className="ex__body--sm">Small text</small>
+
+      </section>
+
     </Layout>
   )
 }

--- a/examples/simple-app/index.js
+++ b/examples/simple-app/index.js
@@ -1,63 +1,45 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import { Heading, Layout } from 'virtuoso-design-system'
-import 'virtuoso-design-system/dist/styles.css'
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Layout } from 'virtuoso-design-system';
+import 'virtuoso-design-system/dist/styles.css';
 
+/* eslint-disable require-jsdoc */
 function SimpleApp() {
   return (
     <Layout>
-      <Layout.Header title="My App"></Layout.Header>
-
-
-
-
+      <Layout.Header title="My App" />
 
       <p>Example content showing design tokens in action:</p>
 
-
-
-
-
       <ul>
-
         <li className="ex__spacer--margin">
           Am I at least a medium spacer apart from the next list item?
         </li>
-        
+
         <li className="ex__color--primaryBlue ex__spacer--padding">
           This background should be primary blue with some ample padding.
         </li>
-        
+
         <li className="ex__spacer--padding ex__color--primarySlate ex__border--rounded">
           I should be primary slate with a rounded border.
         </li>
 
-        <li className="ex__shadow--hover">
-          Note my hovering shadow…
-        </li>
-
+        <li className="ex__shadow--hover">Note my hovering shadow…</li>
       </ul>
-      
-      
-      
-      
-      
-      <section>
 
+      <section>
         <h1 className="ex__head--xl">Heading XL</h1>
         <h2 className="ex__head--lg">Heading LG</h2>
         <h3 className="ex__head--md">Heading MD</h3>
         <h4 className="ex__head--sm">Heading small</h4>
         <h5 className="ex__head--xs">Heading xs</h5>
         <h6 className="ex__head--xxs">Heading xs</h6>
-        
+
         <p className="ex__body--md">Body copy</p>
         <small className="ex__body--sm">Small text</small>
-
       </section>
-
     </Layout>
-  )
+  );
 }
 
-ReactDOM.render(<SimpleApp/>, document.getElementById('mount'));
+ReactDOM.render(<SimpleApp />, document.getElementById('mount'));

--- a/examples/simple-app/package.json
+++ b/examples/simple-app/package.json
@@ -1,6 +1,11 @@
 {
   "name": "simple-app",
   "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/avkvirtru/virtuoso-design-system.git"
+  },
+  "license": "ISC",
   "scripts": {
     "start": "parcel serve --no-cache index.html"
   },

--- a/examples/simple-app/package.json
+++ b/examples/simple-app/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "virtuoso-design-system": "^1.3.1"
+    "virtuoso-design-system": "latest"
   },
   "devDependencies": {
     "parcel": "^2.0.0-beta.1"

--- a/examples/simple-app/package.json
+++ b/examples/simple-app/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "virtuoso-design-system": "^1.0"
+    "virtuoso-design-system": "^1.3.1"
   },
   "devDependencies": {
     "parcel": "^2.0.0-beta.1"


### PR DESCRIPTION
### Proposed Changes
- show design tokens & fonts in example app

🚧 **PR should be squashed into one commit**

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors

### Testing Instructions

- pull down locally
- `cd examples/simple-app`
- `npm i virtuoso-design-system`
- `npm start`
- You should see the new simple app content at http://localhost:1234

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/44370126/90425622-e883c780-e074-11ea-9017-5cdfe6088575.png">
