### PR TITLE
docs: restore introductory pages and sort them first

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -4,6 +4,7 @@ module.exports = {
   stories: [
     // Make Introduction appear first in list of stories.
     '../stories/Intro.stories.@(js|mdx)',
+    '../stories/Intro*.stories.(js|mdx)',
     // // include antd stories
     '../stories/antd/*.@(js|mdx|ts|tsx)',
     '../stories/antd/**/*.@(ts|tsx|jsx)',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -61,3 +61,11 @@ addDecorator(Story => (
 ));
 
 addDecorator(withKnobs);
+
+export const parameters = {
+  options: {
+    storySort: {
+      order: ['Basics', 'virtru', 'antd'], 
+    },
+  },
+};

--- a/stories/Intro-typography-stickersheet.stories.mdx
+++ b/stories/Intro-typography-stickersheet.stories.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 import { StickerSheet } from './storybook-components';
 import { Layout } from '@';
 
-<Meta title="Stickersheets / Typography" />
+<Meta title="Basics/Typography" />
 
 The following stickersheet dis
 


### PR DESCRIPTION
### Proposed Changes
1. Reintroduce the introductory pages from v1 that went missing in the migration to v2/v3
2. Change sort order of story groups

|before|after|
|-------|----|
|AntD|Basics|
|Virtru|Virtru|
|Basics|AntD|

AntD components should be the last resort for our component docs; anything custom we do should always take priority.

### Checklist

- [x] I have added or updated unit tests
- [x] I have added or updated integration tests (if appropriate)
- [x] I have added or updated documentation / readme (if appropriate)
- [x] I have verified that my changes have not introduced new lint errors
- [x] I have added a GitHub labels to the PR for either _patch_, `minor`, or **major**

### Testing Instructions
